### PR TITLE
Add namelist and streams filename parameters to mpas_init

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -56,7 +56,6 @@ module mpas_subdriver
       character(len=*), intent(in), optional :: namelistFileParam
       character(len=*), intent(in), optional :: streamsFileParam
       
-
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
       character(len=StrKIND) :: argument, namelistFile, streamsFile

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -53,8 +53,8 @@ module mpas_subdriver
       type (core_type), intent(inout), pointer :: corelist
       type (domain_type), intent(inout), pointer :: domain_ptr
       integer, intent(in), optional :: mpi_comm
-      character(len=StrKIND), intent(in), optional :: namelistFileParam
-      character(len=StrKIND), intent(in), optional :: streamsFileParam
+      character(len=*), intent(in), optional :: namelistFileParam
+      character(len=*), intent(in), optional :: streamsFileParam
       
 
       integer :: iArg, nArgs
@@ -112,11 +112,11 @@ module mpas_subdriver
       readNamelistArg = .false.
       readStreamsArg = .false.
 
-      if (present(namelistFileParam)) then
+      if (present(namelistFileParam) .and. len_trim(namelistFileParam) > 0 ) then
          readNamelistArg = .true.
          namelistFile = trim(namelistFileParam)
       endif
-      if (present(streamsFileParam)) then
+      if (present(streamsFileParam)  .and. len_trim(streamsFileParam) > 0 ) then
          readStreamsArg = .true.
          streamsFile = trim(streamsFileParam)
       endif

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -39,7 +39,7 @@ module mpas_subdriver
    contains
 
 
-   subroutine mpas_init(corelist, domain_ptr, mpi_comm)
+   subroutine mpas_init(corelist, domain_ptr, mpi_comm, namelistFileParam, streamsFileParam)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_init, MPAS_build_stream_filename, MPAS_stream_mgr_validate_streams
       use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
@@ -53,6 +53,9 @@ module mpas_subdriver
       type (core_type), intent(inout), pointer :: corelist
       type (domain_type), intent(inout), pointer :: domain_ptr
       integer, intent(in), optional :: mpi_comm
+      character(len=StrKIND), intent(in), optional :: namelistFileParam
+      character(len=StrKIND), intent(in), optional :: streamsFileParam
+      
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -108,6 +111,15 @@ module mpas_subdriver
 
       readNamelistArg = .false.
       readStreamsArg = .false.
+
+      if (present(namelistFileParam)) then
+         readNamelistArg = .true.
+         namelistFile = trim(namelistFileParam)
+      endif
+      if (present(streamsFileParam)) then
+         readStreamsArg = .true.
+         streamsFile = trim(streamsFileParam)
+      endif
 
       nArgs = command_argument_count()
       iArg = 1


### PR DESCRIPTION
This alters the signature of the `mpas_init` subroutine in `mpas_subdriver.F`, adding two optional parameters that allow the caller to pass in filenames for the namelist and streams file. This allows the caller to specify different files to be used, other than `namelist.atmosphere` and `streams.atmosphere` in the working directory. This functionality is critical for several use-cases in MPAS-JEDI, including the `ConvertState` application, which interpolates data between two MPAS meshes of different resolutions.