### PR TITLE
Add cmake option to not build OpenMP by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,13 @@ endif()
 option(MPAS_DOUBLE_PRECISION "Use double precision 64-bit Floating point." TRUE)
 option(MPAS_PROFILE "Enable GPTL profiling" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(MPAS_OPENMP "Enable OpenMP" OFF)
 
 message(STATUS "[OPTION] MPAS_CORES: ${MPAS_CORES}")
 message(STATUS "[OPTION] MPAS_DOUBLE_PRECISION: ${MPAS_DOUBLE_PRECISION}")
 message(STATUS "[OPTION] MPAS_PROFILE: ${MPAS_PROFILE}")
 message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+message(STATUS "[OPTION] MPAS_OPENMP: ${MPAS_OPENMP}")
 
 # Build product output locations
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -100,7 +102,9 @@ macro(mpas_fortran_target _tgt)
     target_compile_definitions(${_tgt} PRIVATE USE_PIO2=1)
 
     # Enable OpenMP support
-    target_link_libraries(${_tgt} PUBLIC OpenMP::OpenMP_Fortran)
+    if(MPAS_OPENMP)
+        target_link_libraries(${_tgt} PUBLIC OpenMP::OpenMP_Fortran)
+    endif()
 
     # Compiler-specific options and flags
     if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,14 @@ if(MPAS_CORES MATCHES " ") #Convert strings separated with spaces to CMake list 
 endif()
 option(MPAS_DOUBLE_PRECISION "Use double precision 64-bit Floating point." TRUE)
 option(MPAS_PROFILE "Enable GPTL profiling" OFF)
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(MPAS_OPENMP "Enable OpenMP" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 message(STATUS "[OPTION] MPAS_CORES: ${MPAS_CORES}")
 message(STATUS "[OPTION] MPAS_DOUBLE_PRECISION: ${MPAS_DOUBLE_PRECISION}")
 message(STATUS "[OPTION] MPAS_PROFILE: ${MPAS_PROFILE}")
-message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 message(STATUS "[OPTION] MPAS_OPENMP: ${MPAS_OPENMP}")
+message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 
 # Build product output locations
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
On Cheyenne, when submitting jobs (for example, #PBS -l select=6:ncpus=32:mpiprocs=32), OMP_NUM_THREADS will default to the value of ncpus (=32 in this example). Either add ompthreads=xx setting to PBS, or setenv OMP_NUM_THREADS xx in the script to specify desired threads.
When mpas/mpas_jedi is compiled with OpenMP and the job is run with more than 1 OMP_NUM_THREADS, it hangs somewhere after  `----- done checking limited-area settings -----` in log.atmosphere.0000.out.
This PR changes the default behavior of cmake from Enable OpenMP to disabled.
