### PR TITLE
Add cmake HIDE_MPI flag to esmf_time_f90 build to prevent double mpi_finalize

### DIFF
--- a/src/external/esmf_time_f90/CMakeLists.txt
+++ b/src/external/esmf_time_f90/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(esmf ${_esmf_time_src})
 mpas_fortran_target(esmf)
 add_library(MPAS::external::esmf ALIAS esmf)
 
+target_compile_definitions(esmf PRIVATE HIDE_MPI=1)
+
 target_include_directories(esmf PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(esmf PUBLIC MPI::MPI_Fortran)


### PR DESCRIPTION
-DHIDE_MPI flag is required in building esmf_time_f90 to prevent calling mpi_finalize twice.
The flag is in src/external/esmf_time_f90/Makefile and should be added in src/external/esmf_time_f90/CMakeLists.txt for cmake.

This fixes the error message:
`*** The MPI_Finalize() function was called after MPI_FINALIZE was invoked.` reported in https://github.com/JCSDA-internal/mpas-bundle/issues/90