### PR TITLE
Properly link pnetcdf library

### DIFF
--- a/cmake/Modules/FindPnetCDF.cmake
+++ b/cmake/Modules/FindPnetCDF.cmake
@@ -138,6 +138,7 @@ if(PnetCDF_Fortran_FOUND AND NOT TARGET PnetCDF::PnetCDF_Fortran)
         set_property(TARGET PnetCDF::PnetCDF_Fortran APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_MODULE_DIR})
     endif()
     set(_new_components 1)
+    target_link_libraries(PnetCDF::PnetCDF_Fortran INTERFACE -lpnetcdf)
 endif()
 
 # PnetCDF::PnetCDF_C imported interface target


### PR DESCRIPTION
This fixes #22 for me on my Mac.

I am not a CMake expert - there may be better ways to to this, but it works.  

I am working on Mac Big Sure with a clang/gfortran/openmpi stack.  I was able to reproduce the error in #22 and this fixed it for me.  If others verify that this works then I will issue a corresponding PR to jedi-cmake next week.  This may also need to be added to the C and CXX targets but this is sufficient for MPAS.

WIth this fix, mpas-bundle builds on my Mac and all mpas-jedi tests pass:

```
100% tests passed, 0 tests failed out of 41
```

----
DESCRIPTION OF CHANGES:
This PR fixes the error linking with PnetCDF when it is built on the Mac machines.

LIST OF MODIFIED FILES:
M cmake/Modules/FindPnetCDF.cmake 

ISSUE
Fixes #22

TESTS CONDUCTED:
WIth this fix, mpas-bundle builds on the Mac machines. No impact on Cheyenne build.

