### PR TITLE
Add GFS O3 Photochemistry scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,12 +234,12 @@ set(MPAS_MAIN_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas.F)
 set(MPAS_SUBDRIVER_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas_subdriver.F)
 
 ## Create targets
-add_subdirectory(src/external/ezxml)         # Target: MPAS::external::ezxml
+add_subdirectory(src/external/ezxml) # Target: MPAS::external::ezxml
 add_subdirectory(src/external/esmf_time_f90) # Target: MPAS::external::esmf_time
-add_subdirectory(src/tools/input_gen)        # Targets: namelist_gen, streams_gen
-add_subdirectory(src/tools/registry)         # Targets: mpas_parse_<core_name>
-add_subdirectory(src/framework)              # Target: MPAS::framework
-add_subdirectory(src/operators)              # Target: MPAS::operators
+add_subdirectory(src/tools/input_gen) # Targets: namelist_gen, streams_gen
+add_subdirectory(src/tools/registry) # Targets: mpas_parse_<core_name>
+add_subdirectory(src/framework) # Target: MPAS::framework
+add_subdirectory(src/operators) # Target: MPAS::operators
 
 foreach(_core IN LISTS MPAS_CORES)
     add_subdirectory(src/core_${_core}) # Target: MPAS::core::<core_name>


### PR DESCRIPTION
Developer: Laura Fowler (NCAR/MMM), with cmake build added by Yonggang Yu (NCAR/MMM).

In this PR, we added the CHEM2D Ozone Photochemistry Parameterization (CHEM2D-OPP) described in McCormack et al. (2006). CHEM2D-OPP is added in the new directory ./src/core_atmosphere/chemistry. When using CHEM2D-OPP, ozone becomes a prognostic variable defined in the "scalars" array. See also https://dtcenter.ucar.edu/gmtb/users/ccpp/docs/sci_doc_v2/GFS_OZPHYS.html.

Now MPAS can set O3 with two options:
1. the existing climatology O3 scheme
```
config_o3climatology            = true
config_o3prognostic             = false
```
This option reads in lat/pressure/month varied O3 climatology data (OZONE_DAT.TBL, OZONE_LAT.TBL, and OZONE_PLEV.TBL) and interpolates into the model levels. During the forecast, 3D climatology O3 field is time-interpolated (no advection) to the forecast time and feed into radiation scheme.

2. the new prognostic O3 scheme
```
config_o3climatology            = false
config_o3prognostic             = true
```

This scheme predicts 3D O3 state from its initial condition (could come from the GFS O3 analysis or our own O3 analysis) via advection and photochemistry process. The scheme needs the predefined O3 reference state (varied with month), which is the same as the O3 climatology data (OZONE_DAT.TBL, OZONE_LAT.TBL, and OZONE_PLEV.TBL)? Now this option outputs 3 4D variables (12 months x 3D fields) for O3 reference state in restart file, which increased the file size substantially. Suggest have them in the 'static' stream as the fixed fields in the subsequent code improvement.

List of modified and added files: total 32 files

M src/core_atmosphere/Makefile
M src/core_atmosphere/Registry.xml
A src/core_atmosphere/chemistry/Makefile
A src/core_atmosphere/chemistry/Registry_chems.xml
A src/core_atmosphere/chemistry/chemistry_opp/Makefile
A src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
A src/core_atmosphere/chemistry/mpas_chemistry_driver.F
A src/core_atmosphere/chemistry/mpas_chemistry_init.F
A src/core_atmosphere/chemistry/mpas_chemistry_interface.F
A src/core_atmosphere/chemistry/mpas_chemistry_manager.F
A src/core_atmosphere/chemistry/mpas_chemistry_opp.F
A src/core_atmosphere/chemistry/mpas_chemistry_packages.F
A src/core_atmosphere/chemistry/mpas_chemistry_todynamics.F
M src/core_atmosphere/dynamics/Makefile
M src/core_atmosphere/dynamics/mpas_atm_time_integration.F
M src/core_atmosphere/mpas_atm_core.F
M src/core_atmosphere/mpas_atm_core_interface.F
M src/core_atmosphere/physics/Makefile
M src/core_atmosphere/physics/mpas_atmphys_control.F
M src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
M src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
M src/core_atmosphere/physics/mpas_atmphys_interface.F
M src/core_atmosphere/physics/mpas_atmphys_vars.F
M src/core_atmosphere/physics/physics_wrf/Makefile
M src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
M src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
M src/core_init_atmosphere/Makefile
M src/core_init_atmosphere/Registry.xml
M src/core_init_atmosphere/mpas_init_atm_cases.F
A src/core_init_atmosphere/mpas_init_atm_o3mr.F

M src/core_atmosphere/CMakeLists.txt
M src/core_init_atmosphere/CMakeLists.txt

Tests conducted:
1. Cycling DA using the option 1, it produced the same results as before.
