### PR TITLE
Interpolation of CHEM2d-OPP data in ./src/core_init_atmosphere

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -524,6 +524,8 @@
 			<var name="h_oml_initial"/>
 			<var name="p_fg"/>
 			<var name="o3mr_fg"/>
+			<var_struct name="chemopp_input"/>
+			<var_struct name="chem_input"/>
 		</stream>
 
 		<stream name="restart" 
@@ -853,9 +855,8 @@
 			<var name="hv_oml"/>
 			<var name="p_fg"/>
 			<var name="o3mr_fg"/>
-			<var name="OPPpres"/>
-			<var name="OPPdata"/>
-			<var name="OPPcoeffs"/>
+			<var_struct name="chemopp_input"/>
+			<var_struct name="chem_input"/>
 		</stream>
 
 		<stream name="output" 

--- a/src/core_atmosphere/chemistry/Makefile
+++ b/src/core_atmosphere/chemistry/Makefile
@@ -11,7 +11,6 @@ dummy:
 
 OBJS = \
 	mpas_chemistry_driver.o \
-	mpas_chemistry_init.o \
 	mpas_chemistry_interface.o \
 	mpas_chemistry_manager.o \
 	mpas_chemistry_opp.o \
@@ -31,9 +30,8 @@ chem_interface: $(OBJS)
 mpas_chemistry_driver.o: \
 	mpas_chemistry_interface.o
 
-mpas_chemistry_init.o: \
+mpas_chemistry_manager.o: \
 	mpas_chemistry_opp.o
-
 
 clean:
 	$(RM) *.o *.mod *.f90 libchem.a

--- a/src/core_atmosphere/chemistry/Makefile
+++ b/src/core_atmosphere/chemistry/Makefile
@@ -15,6 +15,7 @@ OBJS = \
 	mpas_chemistry_interface.o \
 	mpas_chemistry_manager.o \
 	mpas_chemistry_opp.o \
+	mpas_chemistry_packages.o \
 	mpas_chemistry_todynamics.o
 
 core_chemistry_opp:

--- a/src/core_atmosphere/chemistry/Registry_chems.xml
+++ b/src/core_atmosphere/chemistry/Registry_chems.xml
@@ -2,6 +2,11 @@
 <!-- ozone chemistry:                                                                                          -->
 <!-- ========================================================================================================= -->
 
+ <packages>
+      <package name="chem2dopp_in" description="CHEM2D ozone photochemistry parameterization."/>
+ </packages>
+
+
  <dims>
       <dim name="nOPPLevels" definition="53"
            description="The number of levels in the linearized CHEM2D-OPP (McCormack et al.,2006)"/>
@@ -15,7 +20,8 @@
 
       <var_array name="scalars" type="real" dimensions="nVertLevels nCells Time">
            <var name="qo3" array_group="passive" units="kg kg^{-1}"
-                description="Ozone mixing ratio"/>
+                description="Ozone mixing ratio"
+                packages="chem2dopp_in"/>
       </var_array>
 
  </var_struct>
@@ -25,7 +31,8 @@
 
       <var_array name="scalars_tend" type="real" dimensions="nVertLevels nCells Time">
            <var name="tend_qo3" name_in_code="qo3" array_group="passive" units="kg m^{-3} s^{-1}"
-                description="Tendency of ozone mass per unit volume divided by d(zeta)/dz"/>
+                description="Tendency of ozone mass per unit volume divided by d(zeta)/dz"
+                packages="chem2dopp_in"/>
       </var_array>
 
  </var_struct>
@@ -35,14 +42,17 @@
 
       <!-- Monthly mean pressure and coefficients needed in the linearized CHEM2D-OPP: -->
       <var name="OPPpres" type="real" dimensions="nOPPLevels" units="Pa"
-           description="fixed pressure levels in the linearized CHEM2D-OPP (McCormack et al.,2006)"/>
+           description="fixed pressure levels in the linearized CHEM2D-OPP (McCormack et al.,2006)"
+           packages="chem2dopp_in"/>
 
       <var name="OPPdata" type="real" dimensions="nMonths nOPPCoeffs nOPPLevels nCells" units="various"
-           description="monthly-mean coefficients used in the linearized CHEM2D-OPP (McCormack et al.,2006)"/>
+           description="monthly-mean coefficients used in the linearized CHEM2D-OPP (McCormack et al.,2006)"
+           packages="chem2dopp_in"/>
 
       <!-- Coefficients needed in the linearized CHEM2D-OPP interpolated to the actual timestamp: -->
       <var name="OPPcoeffs" type="real" dimensions="nOPPCoeffs nOPPLevels nCells Time" units="various"
-           description="coefficients used in the linearized CHEM2D-OPP at the actual timestamp"/>
+           description="coefficients used in the linearized CHEM2D-OPP at the actual timestamp"
+           packages="chem2dopp_in"/>
 
  </var_struct>
 
@@ -50,16 +60,20 @@
  <var_struct name="diag_chemistry" time_levs="1">
 
       <var name="oppdiag1" type="real" dimensions="nVertLevels nCells Time" units=" "
-           description="diagnostic 1 from the linearized CHEM2D-OPP"/>
+           description="diagnostic 1 from the linearized CHEM2D-OPP"
+           packages="chem2dopp_in"/>
 
       <var name="oppdiag2" type="real" dimensions="nVertLevels nCells Time" units=" "
-           description="diagnostic 2 from the linearized CHEM2D-OPP"/>
+           description="diagnostic 2 from the linearized CHEM2D-OPP"
+           packages="chem2dopp_in"/>
 
       <var name="oppdiag3" type="real" dimensions="nVertLevels nCells Time" units=" "
-           description="diagnostic 3 from the linearized CHEM2D-OPP"/>
+           description="diagnostic 3 from the linearized CHEM2D-OPP"
+           packages="chem2dopp_in"/>
 
       <var name="oppdiag4" type="real" dimensions="nVertLevels nCells Time" units=" "
-           description="diagnostic 4 from the linearized CHEM2D-OPP"/>
+           description="diagnostic 4 from the linearized CHEM2D-OPP"
+           packages="chem2dopp_in"/>
 
       <var name="oppdiag5" type="real" dimensions="nVertLevels nCells Time" units=" "
            description="diagnostic 5 from the linearized CHEM2D-OPP"/>
@@ -91,7 +105,8 @@
  <var_struct name="tend_chemistry" time_levs="1">
 
       <var name="qo3oppten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
-           description="ozone tendency from the linearized CHEM2D-OPP"/>
+           description="ozone tendency from the linearized CHEM2D-OPP"
+           packages="chem2dopp_in"/>
 
  </var_struct>
 

--- a/src/core_atmosphere/chemistry/Registry_chems.xml
+++ b/src/core_atmosphere/chemistry/Registry_chems.xml
@@ -38,7 +38,7 @@
  </var_struct>
 
 
- <var_struct name="chem_input" time_levs="1">
+ <var_struct name="chemopp_input" time_levs="1">
 
       <!-- Monthly mean pressure and coefficients needed in the linearized CHEM2D-OPP: -->
       <var name="OPPpres" type="real" dimensions="nOPPLevels" units="Pa"
@@ -48,6 +48,11 @@
       <var name="OPPdata" type="real" dimensions="nMonths nOPPCoeffs nOPPLevels nCells" units="various"
            description="monthly-mean coefficients used in the linearized CHEM2D-OPP (McCormack et al.,2006)"
            packages="chem2dopp_in"/>
+
+ </var_struct>
+
+
+ <var_struct name="chem_input" time_levs="1">
 
       <!-- Coefficients needed in the linearized CHEM2D-OPP interpolated to the actual timestamp: -->
       <var name="OPPcoeffs" type="real" dimensions="nOPPCoeffs nOPPLevels nCells Time" units="various"

--- a/src/core_atmosphere/chemistry/Registry_chems.xml
+++ b/src/core_atmosphere/chemistry/Registry_chems.xml
@@ -61,6 +61,30 @@
       <var name="oppdiag4" type="real" dimensions="nVertLevels nCells Time" units=" "
            description="diagnostic 4 from the linearized CHEM2D-OPP"/>
 
+      <var name="oppdiag5" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 5 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag6" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 6 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag7" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 7 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag8" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 8 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag9" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 9 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag10" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 10 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag11" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 11 from the linearized CHEM2D-OPP"/>
+
+      <var name="oppdiag12" type="real" dimensions="nVertLevels nCells Time" units=" "
+           description="diagnostic 11 from the linearized CHEM2D-OPP"/>
+
  </var_struct>
 
 

--- a/src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
+++ b/src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
@@ -146,7 +146,8 @@
 
 !=================================================================================================================
  subroutine o3_gfs_run(im,levs,ko3,dt,oz,tin,po3,prsl,prdout,pl_coeff,delp,ldiag3d,qdiag3d, &
-                       ozp1,ozp2,ozp3,ozp4,grav,errmsg,errflg)
+                       ozp1,ozp2,ozp3,ozp4,ozp5,ozp6,ozp7,ozp8,ozp9,ozp10,ozp11,ozp12,grav, &
+                       errmsg,errflg)
 !=================================================================================================================
 
 !input arguments:
@@ -182,6 +183,16 @@
     ozp2,    &! cumulative change in ozone concentration due to ozone mixing ratio (kg kg-1).
     ozp3,    &! cumulative_change_in_ozone_concentration_due_to_temperature (kg kg-1).
     ozp4      ! cumulative change in ozone concentration due to overhead ozone column (kg kg-1).
+
+ real(kind=kind_phys),intent(inout),dimension(im,levs):: &
+    ozp5,   &!
+    ozp6,   &!
+    ozp7,   &!
+    ozp8,   &!
+    ozp9,   &!
+    ozp10,  &!
+    ozp11,  &!
+    ozp12    !
 
  real(kind=kind_phys),intent(inout),dimension(im,levs):: &
     oz        ! ozone mixing ratio (kg/kg).
@@ -301,6 +312,18 @@
           ozp2(i,l) = ozp2(i,l) + (oz(i,l) - ozib(i))
           ozp3(i,l) = ozp3(i,l) + prod(i,3)*(tin(i,l)-prod(i,5))*dt
           ozp4(i,l) = ozp4(i,l) + prod(i,4)*(colo3(i,l)-coloz(i,l))*dt
+
+          ozp5(i,l)  = prod(i,1)
+          ozp6(i,l)  = prod(i,2)
+          ozp7(i,l)  = prod(i,3)
+          ozp8(i,l)  = prod(i,4)
+          ozp9(i,l)  = prod(i,5)
+          ozp10(i,l) = prod(i,6)
+
+          ozp11(i,l) = prod(i,1)                         &
+                     + prod(i,3)*(tin(i,l)-prod(i,5))    &
+                     + prod(i,4)*(colo3(i,l)-coloz(i,l))
+          ozp12(i,l) = prod(i,6) - ozp5(i,l)/prod(i,2)
        enddo
     endif
 

--- a/src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
+++ b/src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
@@ -185,14 +185,14 @@
     ozp4      ! cumulative change in ozone concentration due to overhead ozone column (kg kg-1).
 
  real(kind=kind_phys),intent(inout),dimension(im,levs):: &
-    ozp5,   &!
-    ozp6,   &!
-    ozp7,   &!
-    ozp8,   &!
-    ozp9,   &!
-    ozp10,  &!
-    ozp11,  &!
-    ozp12    !
+    ozp5,    &!
+    ozp6,    &!
+    ozp7,    &!
+    ozp8,    &!
+    ozp9,    &!
+    ozp10,   &!
+    ozp11,   &!
+    ozp12     !
 
  real(kind=kind_phys),intent(inout),dimension(im,levs):: &
     oz        ! ozone mixing ratio (kg/kg).
@@ -229,11 +229,19 @@
 !--- save input ozone profiles:
  do k = 1,levs
     do i = 1,im
-       ozi(i,k)  = oz(i,k)
-       ozp1(i,k) = 0.
-       ozp2(i,k) = 0.
-       ozp3(i,k) = 0.
-       ozp4(i,k) = 0.
+       ozi(i,k)   = oz(i,k)
+       ozp1(i,k)  = 0.
+       ozp2(i,k)  = 0.
+       ozp3(i,k)  = 0.
+       ozp4(i,k)  = 0.
+       ozp5(i,k)  = 0.
+       ozp6(i,k)  = 0.
+       ozp7(i,k)  = 0.
+       ozp8(i,k)  = 0.
+       ozp9(i,k)  = 0.
+       ozp10(i,k) = 0.
+       ozp11(i,k) = 0.
+       ozp12(i,k) = 0.
     enddo
  enddo
 
@@ -323,7 +331,7 @@
           ozp11(i,l) = prod(i,1)                         &
                      + prod(i,3)*(tin(i,l)-prod(i,5))    &
                      + prod(i,4)*(colo3(i,l)-coloz(i,l))
-          ozp12(i,l) = prod(i,6) - ozp5(i,l)/prod(i,2)
+!         ozp12(i,l) = prod(i,6) - ozp5(i,l)/prod(i,2)
        enddo
     endif
 

--- a/src/core_atmosphere/chemistry/mpas_chemistry_driver.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_driver.F
@@ -40,6 +40,7 @@
 !local variables and pointers:
  type(mpas_pool_type),pointer:: configs
  type(mpas_pool_type),pointer:: mesh
+ type(mpas_pool_type),pointer:: chemopp_input
  type(mpas_pool_type),pointer:: chem_input
  type(mpas_pool_type),pointer:: state
  type(mpas_pool_type),pointer:: diag
@@ -81,6 +82,7 @@
  do while(associated(block))
 
     call mpas_pool_get_subpool(block%structs,'mesh'          ,mesh          )
+    call mpas_pool_get_subpool(block%structs,'chemopp_input' ,chemopp_input )
     call mpas_pool_get_subpool(block%structs,'chem_input'    ,chem_input    )
     call mpas_pool_get_subpool(block%structs,'state'         ,state         )
     call mpas_pool_get_subpool(block%structs,'diag'          ,diag          )
@@ -97,7 +99,7 @@
 
 
     !--- initializes local arrays needed to run CHEM2D-OPP:
-    call mpas_chems%from_MPAS(block%configs,mesh,chem_input,diag,state,time_lev)
+    call mpas_chems%from_MPAS(block%configs,mesh,chemopp_input,chem_input,diag,state,time_lev)
 
 
     !--- call to OPP:

--- a/src/core_atmosphere/chemistry/mpas_chemistry_driver.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_driver.F
@@ -138,6 +138,14 @@
                     mpas_chems%qozd2,     &
                     mpas_chems%qozd3,     &
                     mpas_chems%qozd4,     &
+                    mpas_chems%qozd5,     &
+                    mpas_chems%qozd6,     &
+                    mpas_chems%qozd7,     &
+                    mpas_chems%qozd8,     &
+                    mpas_chems%qozd9,     &
+                    mpas_chems%qozd10,    &
+                    mpas_chems%qozd11,    &
+                    mpas_chems%qozd12,    &
                     mpas_chems%grav_c,    &
                     errmsg,               &
                     errflg                &

--- a/src/core_atmosphere/chemistry/mpas_chemistry_init.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_init.F
@@ -5,59 +5,41 @@
  use mpas_derived_types,only: mpas_pool_type
  use mpas_pool_routines,only: mpas_pool_get_config
 
- use mpas_chemistry_opp,only: init_opp
-
+ use mpas_init_chem2DOPP,only: init_chem2DOPP
 
  implicit none
  private
- public:: chemistry_init
+ public:: chemistry_init2DOPP
 
 
 !initialization and interpolation to MPAS mesh of input data needed to run the CHEM2D Ozone Photochemistry
 !Parameterization (CHEM2D-OPP) of McCormack et al. (2006).
-
-!add-ons and modifications to sourcecode:
-!----------------------------------------
-! * in subroutine chemistry_init, hit return if config_o3prognostic is set to false.
-!   Laura D. Fowler (laura@ucar.edu) / 2021-04-08.
 
 
  contains
 
 
 !=================================================================================================================
- subroutine chemistry_init(configs,mesh,chem_input)
+ subroutine chemistry_init2DOPP(mesh,chemopp_input)
 !=================================================================================================================
 
 !input arguments:
- type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
 
 
 !inout arguments:
- type(mpas_pool_type),intent(inout):: chem_input
-
-
-!local variables and pointers:
- logical,pointer:: o3prognostic
+ type(mpas_pool_type),intent(inout):: chemopp_input
 
 !-----------------------------------------------------------------------------------------------------------------
-
-!--- hit return if config_o3prognostic is set to false:
- call mpas_pool_get_config(configs,'config_o3prognostic',o3prognostic)
- if(.not. o3prognostic) return
-
  call mpas_log_write(' ')
- call mpas_log_write('--- enter subroutine chemistry_init:')
+ call mpas_log_write('--- enter subroutine chemistry_init2DOPP:')
+ 
+ call init_chem2DOPP(mesh,chemopp_input)
 
-!--- initializes the input data need to run the CHEM2D-OPP of McCormack et al. (2006):
- call init_opp(configs,mesh,chem_input)
-
-
- call mpas_log_write('--- end subroutine chemistry_init:')
+ call mpas_log_write('--- end subroutine chemistry_init2DOPP:')
  call mpas_log_write(' ')
 
- end subroutine chemistry_init
+ end subroutine chemistry_init2DOPP
 
 !=================================================================================================================
  end module mpas_chemistry_init

--- a/src/core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F
@@ -1,0 +1,233 @@
+!=================================================================================================================
+ module mpas_init_chem2DOPP
+ use mpas_kind_types
+ use mpas_log,only          : mpas_log_write
+ use mpas_io_units,only     : mpas_new_unit
+ use mpas_derived_types,only: mpas_pool_type
+ use mpas_pool_routines,only: mpas_pool_get_dimension,mpas_pool_get_array
+
+ use mpas_atmphys_constants,only: degrad
+ use mpas_atmphys_utilities,only: physics_error_fatal
+
+ implicit none
+ private
+ public:: init_chem2DOPP
+
+
+ integer,public:: latsozp,levozp,oz_coeff,timeoz
+ real(kind=RKIND),dimension(:),allocatable,public:: oz_lat,oz_pres,oz_time
+ real(kind=RKIND),dimension(:,:,:,:),allocatable,public:: ozplin
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine init_chem2DOPP(mesh,chemopp_input)
+!=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: mesh
+
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: chemopp_input
+
+
+!local variables:
+ logical,pointer:: o3climatology,o3prognostic
+ integer:: i,iCell,i1,i2,k,m,n
+ integer,pointer:: nCells,nMonths,nO3Coeffs,nO3Levels
+
+ real(kind=RKIND):: dlat,dlatCell,lat,lon
+ real(kind=RKIND),dimension(:),pointer:: latCell,lonCell
+ real(kind=RKIND),dimension(:),pointer:: O3pres
+ real(kind=RKIND),dimension(:,:,:,:),pointer:: O3data
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+ call mpas_log_write('--- enter subroutine init_chem2DOPP:')
+
+ call mpas_pool_get_dimension(mesh,'nCells'    ,nCells   )
+ call mpas_pool_get_dimension(mesh,'nMonths'   ,nMonths  )
+ call mpas_pool_get_dimension(mesh,'nOPPLevels',nO3Levels)
+ call mpas_pool_get_dimension(mesh,'nOPPCoeffs',nO3Coeffs)
+
+ call mpas_pool_get_array(mesh,'latCell',latCell)
+ call mpas_pool_get_array(mesh,'lonCell',lonCell)
+
+ call mpas_pool_get_array(chemopp_input,'OPPpres',O3pres)
+ call mpas_pool_get_array(chemopp_input,'OPPdata',O3data)
+
+
+!--- read monthly-mean CHEM2-OPP linearized coefficients:
+ call read_o3data()
+
+
+!--- make sure that the dimensions in the input O3CHem2D-OPP file are the same as the ones set in Registry.xml:
+ if(nO3Levels /= levozp) then
+    call mpas_log_write('--- nO3Levels = $i whereas levozp = $i',intArgs=(/nO3Levels,levozp/))
+    call physics_error_fatal('--- nO3Levels is different than levozp from input data file:')
+ elseif(nO3Coeffs /= oz_coeff) then
+    call mpas_log_write('--- nO3Coeffs = $i whereas oz_coeff = $i',intArgs=(/nO3Coeffs,oz_coeff/))
+ elseif(nMonths /= timeoz) then
+    call mpas_log_write('--- nMonths = $i whereas timeiz = $i',intArgs=(/nMonths,timeoz/))
+ endif
+
+
+!--- interpolation of input CHEM2D-OPP coefficients to the MPAS grid: this loop is the same as in subroutine
+!    init_o3climatology (see module mpas_atmphys_o3climatology, lines 149-184):
+ do k = 1,nO3Levels
+    O3pres(k) = oz_pres(k)
+ enddo
+
+ do iCell = 1,nCells
+    lat = latCell(iCell)/degrad
+    lon = lonCell(iCell)/degrad
+    if(lat .gt. oz_lat(latsozp)) then
+     i1 = latsozp
+     i2 = latsozp
+    elseif(lat .lt. oz_lat(1)) then
+       i1 = 1
+       i2 = 1
+    else
+       do i = 1, latsozp
+          if(lat.ge.oz_lat(i) .and. lat.lt.oz_lat(i+1)) exit
+       enddo
+       i1 = i
+       i2 = i+1
+    endif
+
+    do m = 1,nMonths
+       do n = 1,nO3Coeffs
+          do k = 1,nO3Levels
+             dlat     = oz_lat(i2)-oz_lat(i1)
+             dlatCell = lat-oz_lat(i1)
+
+             if(dlat == 0.) then
+                O3data(m,n,k,iCell) = ozplin(i1,k,n,m)
+             else
+                O3data(m,n,k,iCell) = ozplin(i1,k,n,m) &
+                     + (ozplin(i2,k,n,m)-ozplin(i1,k,n,m))*dlatCell/dlat
+             endif
+          enddo
+       enddo
+    enddo
+ enddo
+
+ do m = 1,nMonths
+    do iCell = 1,nCells
+       do k = 1,nO3Levels
+          if(m.eq.1 .or. m.eq.nMonths) &
+             call mpas_log_write('$i $i $i $r $r $r $r $r $r $r',intArgs=(/m,iCell,k/),realArgs=(/O3pres(k), &
+                                (O3data(m,n,k,iCell),n=1,nO3Coeffs)/))
+       enddo
+       call mpas_log_write(' ')
+    enddo
+    call mpas_log_write(' ')
+ enddo
+
+ call mpas_log_write('--- end subroutine init_chem2DOPP:')
+
+ end subroutine init_chem2DOPP
+
+!=================================================================================================================
+ subroutine read_o3data()
+!=================================================================================================================
+
+!local variables and arrays:
+ integer:: i,k,ll,n,o3unit
+ integer:: latsozc,levozc,timeozc
+
+ real(kind=4),dimension(:),allocatable:: oz_lat4,oz_pres4,oz_time4,tempin
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+ call mpas_log_write('--- enter subroutine read_o3data:')
+
+!--- define unit:
+ call mpas_new_unit(o3unit)
+ if(o3unit < 0) &
+    call physics_error_fatal('GFSprogO3 for MPAS: All file units are taken. Change maxUnits in mpas_io_units.F')
+
+
+!--- prognostic ozone input data file:
+ open(unit=o3unit,file='global_o3prdlos.f77',form='unformatted',convert='big_endian')
+
+
+!--- read in indices:
+ read (o3unit) oz_coeff,latsozp,levozp,timeoz
+ call mpas_log_write('reading in o3data from global_o3prdlos.f77: ')
+ call mpas_log_write('oz_coeff = $i',intArgs=(/oz_coeff/))
+ call mpas_log_write('latsozp  = $i',intArgs=(/latsozp/))
+ call mpas_log_write('levozp   = $i',intArgs=(/levozp/))
+ call mpas_log_write('timeoz   = $i',intArgs=(/timeoz/))
+
+
+!--- read in data
+!---   oz_lat   -  latitude of data        (-90 to 90)
+!---   oz_pres  -  vertical pressure level (mb)
+!---   oz_time  -  time coordinate         (days)
+!---
+
+ if(.not.allocated(oz_lat) ) allocate(oz_lat(latsozp)    )
+ if(.not.allocated(oz_pres)) allocate(oz_pres(levozp)    )
+ if(.not.allocated(oz_time)) allocate(oz_time(timeoz+1)  )
+
+ if(.not.allocated(oz_lat4) ) allocate(oz_lat4(latsozp)  )
+ if(.not.allocated(oz_pres4)) allocate(oz_pres4(levozp)  )
+ if(.not.allocated(oz_time4)) allocate(oz_time4(timeoz+1))
+ if(.not.allocated(tempin)  ) allocate(tempin(latsozp)   )
+
+ rewind(o3unit)
+ read(o3unit) oz_coeff,latsozp,levozp,timeoz,oz_lat4,oz_pres4,oz_time4
+
+!--- convert pressure levels from mb to ln(Pa):
+ oz_pres(:) = oz_pres4(:)
+ oz_pres(:) = log(100.0*oz_pres(:))
+ oz_lat(:)  = oz_lat4(:)
+ oz_time(:) = oz_time4(:)
+
+!call mpas_log_write(' ')
+!call mpas_log_write('--- pressure:')
+!do k = 1,levozp
+!   call mpas_log_write('$i $r $r',intArgs=(/k/),realArgs=(/oz_pres4(k),oz_pres(k)/))
+!enddo
+!call mpas_log_write(' ')
+!call mpas_log_write('--- latitude:')
+!do k = 1,latsozp
+!   call mpas_log_write('$i $r',intArgs=(/k/),realArgs=(/oz_lat(k)/))
+!enddo
+!call mpas_log_write(' ')
+!call mpas_log_write('--- oz_time:')
+!do k = 1,timeoz+1
+!   call mpas_log_write('$i $r',intArgs=(/k/),realArgs=(/oz_time(k)/))
+!enddo
+
+!--- read in ozplin which is in order of (latitudes,ozone levels,coeff number,time) where latitudes are on
+!    a uniform gaussian grid:
+ if(.not.allocated(ozplin)) allocate(ozplin(latsozp,levozp,oz_coeff,timeoz))
+
+ do i = 1,timeoz
+    do n = 1,oz_coeff
+       do k = 1,levozp
+          read(o3unit) tempin
+          ozplin(:,k,n,i) = tempin(:)
+       enddo
+    enddo
+ enddo
+
+ if(allocated(oz_lat4) ) deallocate(oz_lat4 )
+ if(allocated(oz_pres4)) deallocate(oz_pres4)
+ if(allocated(oz_time4)) deallocate(oz_time4)
+ if(allocated(tempin)  ) deallocate(tempin  )
+
+
+ close(o3unit)
+ call mpas_log_write('--- end subroutine read_o3data:')
+
+ end subroutine read_o3data
+
+!=================================================================================================================
+ end module mpas_init_chem2DOPP
+!=================================================================================================================

--- a/src/core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F
@@ -115,17 +115,17 @@
     enddo
  enddo
 
- do m = 1,nMonths
-    do iCell = 1,nCells
-       do k = 1,nO3Levels
-          if(m.eq.1 .or. m.eq.nMonths) &
-             call mpas_log_write('$i $i $i $r $r $r $r $r $r $r',intArgs=(/m,iCell,k/),realArgs=(/O3pres(k), &
-                                (O3data(m,n,k,iCell),n=1,nO3Coeffs)/))
-       enddo
-       call mpas_log_write(' ')
-    enddo
-    call mpas_log_write(' ')
- enddo
+!do m = 1,nMonths
+!   do iCell = 1,nCells
+!      do k = 1,nO3Levels
+!         if(m.eq.1 .or. m.eq.nMonths) &
+!            call mpas_log_write('$i $i $i $r $r $r $r $r $r $r',intArgs=(/m,iCell,k/),realArgs=(/O3pres(k), &
+!                               (O3data(m,n,k,iCell),n=1,nO3Coeffs)/))
+!      enddo
+!      call mpas_log_write(' ')
+!   enddo
+!   call mpas_log_write(' ')
+!enddo
 
  call mpas_log_write('--- end subroutine init_chem2DOPP:')
 

--- a/src/core_atmosphere/chemistry/mpas_chemistry_interface.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_interface.F
@@ -21,6 +21,14 @@
     real(kind=RKIND),dimension(:,:),pointer  :: qozd2     => null()
     real(kind=RKIND),dimension(:,:),pointer  :: qozd3     => null()
     real(kind=RKIND),dimension(:,:),pointer  :: qozd4     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd5     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd6     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd7     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd8     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd9     => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd10    => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd11    => null()
+    real(kind=RKIND),dimension(:,:),pointer  :: qozd12    => null()
     real(kind=RKIND),dimension(:,:,:),pointer:: qozcoeffs => null()
 
     !--- local variables from the MPAS dynamical core:
@@ -111,6 +119,14 @@
  if(.not.associated(this%qozd2)    ) allocate(this%qozd2(its:ite,kts:kte)        )
  if(.not.associated(this%qozd3)    ) allocate(this%qozd3(its:ite,kts:kte)        )
  if(.not.associated(this%qozd4)    ) allocate(this%qozd4(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd5)    ) allocate(this%qozd5(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd6)    ) allocate(this%qozd6(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd7)    ) allocate(this%qozd7(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd8)    ) allocate(this%qozd8(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd9)    ) allocate(this%qozd9(its:ite,kts:kte)        )
+ if(.not.associated(this%qozd10)   ) allocate(this%qozd10(its:ite,kts:kte)       )
+ if(.not.associated(this%qozd11)   ) allocate(this%qozd11(its:ite,kts:kte)       )
+ if(.not.associated(this%qozd12)   ) allocate(this%qozd12(its:ite,kts:kte)       )
  if(.not.associated(this%tend_qoz) ) allocate(this%tend_qoz(its:ite,kts:kte)     )
 
  if(.not.associated(this%qozp)     ) allocate(this%qozp(no3levs))
@@ -143,6 +159,14 @@
  if(associated(this%qozd2)    ) deallocate(this%qozd2    )
  if(associated(this%qozd3)    ) deallocate(this%qozd3    )
  if(associated(this%qozd4)    ) deallocate(this%qozd4    )
+ if(associated(this%qozd5)    ) deallocate(this%qozd5    )
+ if(associated(this%qozd6)    ) deallocate(this%qozd6    )
+ if(associated(this%qozd7)    ) deallocate(this%qozd7    )
+ if(associated(this%qozd8)    ) deallocate(this%qozd8    )
+ if(associated(this%qozd9)    ) deallocate(this%qozd9    )
+ if(associated(this%qozd10)   ) deallocate(this%qozd10   )
+ if(associated(this%qozd11)   ) deallocate(this%qozd11   )
+ if(associated(this%qozd12)   ) deallocate(this%qozd12   )
  if(associated(this%tend_qoz) ) deallocate(this%tend_qoz )
 
  if(associated(this%qozp)     ) deallocate(this%qozp     )
@@ -273,6 +297,14 @@
        this%qozd2(i,k)    = 0._RKIND
        this%qozd3(i,k)    = 0._RKIND
        this%qozd4(i,k)    = 0._RKIND
+       this%qozd5(i,k)    = 0._RKIND
+       this%qozd6(i,k)    = 0._RKIND
+       this%qozd7(i,k)    = 0._RKIND
+       this%qozd8(i,k)    = 0._RKIND
+       this%qozd9(i,k)    = 0._RKIND
+       this%qozd10(i,k)   = 0._RKIND
+       this%qozd11(i,k)   = 0._RKIND
+       this%qozd12(i,k)   = 0._RKIND
     enddo
  enddo
 
@@ -347,7 +379,10 @@
 
  real(kind=RKIND):: dt_c
  real(kind=RKIND),dimension(:,:),pointer:: qoz,tend_qoz,qozd1,qozd2,qozd3,qozd4
+ real(kind=RKIND),dimension(:,:),pointer:: qozd5,qozd6,qozd7,qozd8,qozd9,qozd10,qozd11,qozd12
  real(kind=RKIND),dimension(:,:),pointer:: oppdiag1,oppdiag2,oppdiag3,oppdiag4
+ real(kind=RKIND),dimension(:,:),pointer:: oppdiag5,oppdiag6,oppdiag7,oppdiag8,oppdiag9,oppdiag10, &
+                                           oppdiag11,oppdiag12
  real(kind=RKIND),dimension(:,:),pointer:: qo3oppten
 
 !-----------------------------------------------------------------------------------------------------------------
@@ -358,6 +393,15 @@
  call mpas_pool_get_array(diag_chemistry,'oppdiag2',oppdiag2)
  call mpas_pool_get_array(diag_chemistry,'oppdiag3',oppdiag3)
  call mpas_pool_get_array(diag_chemistry,'oppdiag4',oppdiag4)
+
+ call mpas_pool_get_array(diag_chemistry,'oppdiag5' ,oppdiag5 )
+ call mpas_pool_get_array(diag_chemistry,'oppdiag6' ,oppdiag6 )
+ call mpas_pool_get_array(diag_chemistry,'oppdiag7' ,oppdiag7 )
+ call mpas_pool_get_array(diag_chemistry,'oppdiag8' ,oppdiag8 )
+ call mpas_pool_get_array(diag_chemistry,'oppdiag9' ,oppdiag9 )
+ call mpas_pool_get_array(diag_chemistry,'oppdiag10',oppdiag10)
+ call mpas_pool_get_array(diag_chemistry,'oppdiag11',oppdiag11)
+ call mpas_pool_get_array(diag_chemistry,'oppdiag12',oppdiag12)
 
  call mpas_pool_get_array(tend_chemistry,'qo3oppten',qo3oppten)
 
@@ -378,12 +422,20 @@
  qozd3    => this%qozd3
  qozd4    => this%qozd4
 
+ qozd5    => this%qozd5
+ qozd6    => this%qozd6
+ qozd7    => this%qozd7
+ qozd8    => this%qozd8
+ qozd9    => this%qozd9
+ qozd10   => this%qozd10
+ qozd11   => this%qozd11
+ qozd12   => this%qozd12
+
  do i = its,ite
     do k = kts,kte
        tend_qoz(i,k) = (qoz(i,k)-tend_qoz(i,k))/dt_c
     enddo
  enddo
-
 
 !---
  do i = its,ite
@@ -395,6 +447,20 @@
        qo3oppten(k,i) = tend_qoz(i,k)
     enddo
  enddo
+
+ do i = its,ite
+    do k = kts,kte
+       oppdiag5(k,i)  = qozd5(i,k)
+       oppdiag6(k,i)  = qozd6(i,k)
+       oppdiag7(k,i)  = qozd7(i,k)
+       oppdiag8(k,i)  = qozd8(i,k)
+       oppdiag9(k,i)  = qozd9(i,k)
+       oppdiag10(k,i) = qozd10(i,k)
+       oppdiag11(k,i) = qozd11(i,k)
+       oppdiag12(k,i) = qozd12(i,k)
+    enddo
+ enddo
+
 
  call mpas_log_write('--- end subroutine mpas_chemistry_to_MPAS:')
 

--- a/src/core_atmosphere/chemistry/mpas_chemistry_interface.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_interface.F
@@ -183,12 +183,13 @@
  end subroutine mpas_chemistry_deallocate
 
 !=================================================================================================================
- subroutine mpas_chemistry_from_MPAS(this,configs,mesh,chem_input,diag,state,time_lev)
+ subroutine mpas_chemistry_from_MPAS(this,configs,mesh,chemopp_input,chem_input,diag,state,time_lev)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: chemopp_input
  type(mpas_pool_type),intent(in):: chem_input
  type(mpas_pool_type),intent(in):: diag
  type(mpas_pool_type),intent(in):: state
@@ -232,8 +233,8 @@
  call mpas_pool_get_dimension(mesh,'nOPPLevels',nOPPLevels)
  call mpas_pool_get_dimension(mesh,'nOPPCoeffs',nOPPCoeffs)
 
- call mpas_pool_get_array(chem_input,'OPPpres'  ,OPPpres  )
- call mpas_pool_get_array(chem_input,'OPPcoeffs',OPPcoeffs)
+ call mpas_pool_get_array(chemopp_input,'OPPpres'  ,OPPpres  )
+ call mpas_pool_get_array(chem_input   ,'OPPcoeffs',OPPcoeffs)
 
 
 !--- dimensions and arrays for mesh and meteorological fields:

--- a/src/core_atmosphere/chemistry/mpas_chemistry_manager.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_manager.F
@@ -45,6 +45,7 @@
  type(block_type),pointer    :: block
  type(mpas_pool_type),pointer:: mesh
  type(mpas_pool_type),pointer:: chem_input
+ type(mpas_pool_type),pointer:: chemopp_input
 
  logical,pointer:: o3prognostic
 
@@ -93,14 +94,15 @@
 
  block => domain%blocklist
  do while(associated(block))
-    call mpas_pool_get_subpool(block%structs,'mesh'      ,mesh      )
-    call mpas_pool_get_subpool(block%structs,'chem_input',chem_input)
+    call mpas_pool_get_subpool(block%structs,'mesh'         ,mesh         )
+    call mpas_pool_get_subpool(block%structs,'chem_input'   ,chem_input   )
+    call mpas_pool_get_subpool(block%structs,'chemopp_input',chemopp_input)
 
     !update the coefficients for the GFS linearized CHEM2D-OPP (Mc Cormack et al. 2006):
     if(mpas_is_alarm_ringing(clock,oppAlarmID,ierr=ierr)) then
        call mpas_reset_clock_alarm(clock,oppAlarmID,ierr=ierr)
        call mpas_log_write('--- time to update CHEM2D-OPP coefficients.')
-       call opp_from_MPAS(julday,curr_julday,mesh,chem_input)
+       call opp_from_MPAS(julday,curr_julday,mesh,chemopp_input,chem_input)
     endif
 
     block => block%next

--- a/src/core_atmosphere/chemistry/mpas_chemistry_opp.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_opp.F
@@ -143,11 +143,12 @@
  end subroutine init_opp
 
 !=================================================================================================================
- subroutine opp_from_MPAS(julian,curr_julday,mesh,chem_input)
+ subroutine opp_from_MPAS(julian,curr_julday,mesh,chemopp_input,chem_input)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: chemopp_input
  integer,intent(in):: julian
  real(kind=RKIND):: curr_julday
 
@@ -183,8 +184,8 @@
  call mpas_pool_get_dimension(mesh,'nOPPLevels' ,nO3Levels  )
  call mpas_pool_get_dimension(mesh,'nOPPCoeffs' ,nO3Coeffs  )
 
- call mpas_pool_get_array(chem_input,'OPPdata'  ,O3data  )
- call mpas_pool_get_array(chem_input,'OPPcoeffs',O3coeffs)
+ call mpas_pool_get_array(chemopp_input,'OPPdata'  ,O3data  )
+ call mpas_pool_get_array(chem_input   ,'OPPcoeffs',O3coeffs)
 
 !--- for now, fix the array GFSO3coeffs to GFSO3data for July:
 !imonth = 7
@@ -231,6 +232,7 @@
  call mpas_log_write('np    = $i',intArgs =(/np/))
  call mpas_log_write('fact1 = $r',realArgs=(/fact1/))
  call mpas_log_write('fact2 = $r',realArgs=(/fact2/))
+
 
 !time interpolation:
  do iCell = 1,nCellsSolve

--- a/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
@@ -24,13 +24,15 @@
 
 
 !=================================================================================================================
- function chemistry_setup_packages(configs,packages,iocontext) result(ierr)
+ function chemistry_setup_packages(configs,packages,iocontext,init) result(ierr)
 !=================================================================================================================
 
 !inout arguments:
  type (mpas_pool_type), intent(inout) :: configs
  type (mpas_pool_type), intent(inout) :: packages
  type (mpas_io_context_type), intent(inout) :: iocontext
+
+ integer, intent(in), optional :: init
 
 !local variables:
  logical,pointer:: o3prognostic
@@ -44,12 +46,15 @@
 
  ierr = 0
 
+ call mpas_log_write(' ')
  call mpas_log_write('----- Setting up package variables -----')
- call mpas_log_write('')
 
 !--- initialization of all packages for parameterizations of cloud microphysics:
-
- call mpas_pool_get_config(configs,'config_o3prognostic',o3prognostic)
+ if(present(init) .and. init == 1) then
+    call mpas_pool_get_config(configs,'config_use_chemopp',o3prognostic)
+ else
+    call mpas_pool_get_config(configs,'config_o3prognostic',o3prognostic)
+ endif
 
  nullify(chem2dopp_in)
  call mpas_pool_get_package(packages,'chem2dopp_inActive',chem2dopp_in)

--- a/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
@@ -1,0 +1,83 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_chemistry_packages
+ use mpas_kind_types
+ use mpas_derived_types,only : mpas_pool_type,mpas_io_context_type,MPAS_LOG_ERR
+ use mpas_pool_routines,only : mpas_pool_get_config,mpas_pool_get_package
+ use mpas_log,only : mpas_log_write
+
+ implicit none
+ private
+ public:: chemistry_setup_packages
+
+!mpas_chemistry_packages contains the definitions of all chemistry packages.
+!Laura D. Fowler (laura@ucar.edu) / 2022-07-27.
+
+
+ contains
+
+
+!=================================================================================================================
+ function chemistry_setup_packages(configs,packages,iocontext) result(ierr)
+!=================================================================================================================
+
+!inout arguments:
+ type (mpas_pool_type), intent(inout) :: configs
+ type (mpas_pool_type), intent(inout) :: packages
+ type (mpas_io_context_type), intent(inout) :: iocontext
+
+!local variables:
+ logical,pointer:: o3prognostic
+ logical,pointer:: chem2dopp_in
+
+ integer :: ierr
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine chemistry_setup_packages:')
+
+ ierr = 0
+
+ call mpas_log_write('----- Setting up package variables -----')
+ call mpas_log_write('')
+
+!--- initialization of all packages for parameterizations of cloud microphysics:
+
+ call mpas_pool_get_config(configs,'config_o3prognostic',o3prognostic)
+
+ nullify(chem2dopp_in)
+ call mpas_pool_get_package(packages,'chem2dopp_inActive',chem2dopp_in)
+
+ if(.not.associated(chem2dopp_in)) then
+    call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
+    call mpas_log_write('* Error while setting up packages chemistry options in atmosphere core.'             ,messageType=MPAS_LOG_ERR)
+    call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
+    ierr = 1
+    return
+ endif
+
+ chem2dopp_in   = .false.
+
+ if(o3prognostic == .true.) then
+    chem2dopp_in = .true.
+ endif
+
+ call mpas_log_write('    chem2dopp_in            = $l', logicArgs=(/chem2dopp_in/))
+
+!call mpas_log_write('--- enter subroutine chemistry_setup_packages:')
+ call mpas_log_write('')
+
+ end function chemistry_setup_packages
+
+!=================================================================================================================
+ end module mpas_chemistry_packages
+!=================================================================================================================
+
+
+

--- a/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_packages.F
@@ -64,7 +64,7 @@
 
  chem2dopp_in   = .false.
 
- if(o3prognostic == .true.) then
+ if(o3prognostic) then
     chem2dopp_in = .true.
  endif
 

--- a/src/core_atmosphere/chemistry/mpas_chemistry_todynamics.F
+++ b/src/core_atmosphere/chemistry/mpas_chemistry_todynamics.F
@@ -55,18 +55,18 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_dimension(state,'index_qo3'  ,index_qo3  )
- call mpas_pool_get_dimension(state,'num_scalars',num_scalars)
-
- call mpas_pool_get_array(tend,'scalars_tend',tend_scalars)
- tend_scalars(index_qo3,:,:) = 0._RKIND
-
 !--- hit return if config_o3prognostic is set to false:
  call mpas_pool_get_config(configs,'config_o3prognostic',o3prognostic)
  if(.not. o3prognostic) return
 
  call mpas_log_write(' ')
  call mpas_log_write('--- enter subroutine chemistry_get_tend:')
+
+ call mpas_pool_get_dimension(state,'index_qo3'  ,index_qo3  )
+ call mpas_pool_get_dimension(state,'num_scalars',num_scalars)
+
+ call mpas_pool_get_array(tend,'scalars_tend',tend_scalars)
+ tend_scalars(index_qo3,:,:) = 0._RKIND
 
  call mpas_pool_get_dimension(mesh,'nCells'     ,nCells     )
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -268,7 +268,6 @@ module atm_core
       use mpas_atmphys_manager
 
 #ifdef DO_CHEMISTRY
-      use mpas_chemistry_init
       use mpas_chemistry_manager
 #endif
 #endif
@@ -287,9 +286,6 @@ module atm_core
       type (mpas_pool_type), pointer :: sfc_input
       type (mpas_pool_type), pointer :: diag_physics
       type (mpas_pool_type), pointer :: atm_input
-#ifdef DO_CHEMISTRY
-      type (mpas_pool_type), pointer :: chem_input
-#endif
 
       integer :: iCell,iEdge,iVertex
       
@@ -458,10 +454,7 @@ module atm_core
                            atm_input, sfc_input)
       endif
 #ifdef DO_CHEMISTRY
-      call mpas_pool_get_subpool(block % structs, 'chem_input', chem_input)
-
       call chemistry_run_init(block % configs, clock)
-      call chemistry_init(block % configs, mesh, chem_input)
 #endif
 #endif
    

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -108,6 +108,9 @@ module atm_core_interface
 #ifdef DO_PHYSICS
       use mpas_atmphys_control
       use mpas_atmphys_packages
+#ifdef DO_CHEMISTRY
+      use mpas_chemistry_packages
+#endif
 #endif
 
       implicit none
@@ -184,6 +187,13 @@ module atm_core_interface
          ierr = ierr + 1
          call mpas_log_write('Package setup failed for atmphys in core_atmosphere', messageType=MPAS_LOG_ERR)
       end if
+#ifdef DO_CHEMISTRY
+      local_ierr = chemistry_setup_packages(configs, packages, iocontext)
+      if (local_ierr /= 0) then
+         ierr = ierr + 1
+         call mpas_log_write('Package setup failed for chemistry in core_atmosphere', messageType=MPAS_LOG_ERR)
+      end if
+#endif
 #endif
 
    end function atm_setup_packages

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -450,7 +450,7 @@
  real (kind=RKIND), dimension(:), pointer :: var2d
  real (kind=RKIND), dimension(:), pointer :: qo3
  real (kind=RKIND), dimension(:,:,:), pointer :: scalars
- integer, pointer :: nCellsSolve
+ integer, pointer :: nCellsSolve, nVertLevels
  integer, pointer :: index_qo3
  character (len=StrKIND), pointer :: gwdo_scheme
  logical, pointer :: o3prognostic, o3climatology
@@ -522,9 +522,11 @@
      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
 
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(statePool, 'index_qo3', index_qo3)
          call mpas_pool_get_array(statePool, 'scalars', scalars, 1)
-         qo3 => scalars(index_qo3,1,:)
+         qo3 => scalars(index_qo3,nVertLevels,:)
 
          maxqo3_local = max(maxqo3_local, maxval(qo3(1:nCellsSolve)))
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -113,6 +113,8 @@
  real(kind=RKIND),dimension(:),pointer:: xland
 
 !-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine cloudiness_from_MPAS:')
 
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
 
@@ -140,6 +142,8 @@
     enddo
  enddo
 
+!call mpas_log_write('--- end subroutine cloudiness_from_MPAS:')
+
  end subroutine cloudiness_from_MPAS
 
 !=================================================================================================================
@@ -158,6 +162,8 @@
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac
 
 !-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine cloudiness_to_MPAS:')
 
  call mpas_pool_get_array(diag_physics,'cldfrac',cldfrac)
 
@@ -168,7 +174,9 @@
  enddo
  enddo
  enddo
- 
+
+!call mpas_log_write('--- end subroutine cloudiness_to_MPAS:')
+
  end subroutine cloudiness_to_MPAS
 
 !=================================================================================================================

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -21,6 +21,9 @@ OBJS =  \
 	mpas_atmphys_functions.o \
 	mpas_atmphys_initialize_real.o \
 	mpas_atmphys_utilities.o \
+	mpas_chemistry_init.o \
+	mpas_chemistry_init_2DOPP.o \
+	mpas_chemistry_packages.o \
 	mpas_stack.o \
 	mpas_kd_tree.o \
 	mpas_parse_geoindex.o
@@ -61,7 +64,8 @@ mpas_init_atm_cases.o: \
 	mpas_init_atm_vinterp.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_functions.o \
-	mpas_atmphys_initialize_real.o
+	mpas_atmphys_initialize_real.o \
+	mpas_chemistry_init.o
 
 mpas_init_atm_hinterp.o: mpas_init_atm_queue.o mpas_init_atm_bitarray.o
 
@@ -75,7 +79,7 @@ mpas_kd_tree.o:
 
 mpas_init_atm_llxy.o:
 
-mpas_init_atm_core_interface.o: mpas_init_atm_core.o
+mpas_init_atm_core_interface.o: mpas_init_atm_core.o mpas_chemistry_packages.o
 
 mpas_init_atm_core.o: mpas_advection.o mpas_init_atm_cases.o
 
@@ -106,6 +110,12 @@ mpas_init_atm_surface.o: \
 mpas_atmphys_initialize_real.o:  \
 	mpas_init_atm_surface.o  \
 	mpas_atmphys_date_time.o \
+	mpas_atmphys_utilities.o
+
+mpas_chemistry_init.o: \
+	mpas_chemistry_init_2DOPP.o
+
+mpas_chemistry_init_2DOPP.o: \
 	mpas_atmphys_utilities.o
 
 clean:

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -181,6 +181,11 @@
                      description="Whether to use specific-humidity as the first-guess moisture variable. If this option is False, relative humidity will be used."
                      possible_values="true or false"/>
 
+                <nml_option name="config_use_chemopp"           type="logical"       default_value="false"
+                     units="-"
+                     description="Whether or not to initialize the CHEM2D-OPP input data for ozone chemistry."
+                     possible_values="true or false"/>
+
         </nml_record>
 
         <nml_record name="vertical_grid" in_defaults="true">
@@ -570,6 +575,7 @@
                         <var name="t2m" packages="met_stage_out"/>
                         <var name="p_fg" packages="met_stage_out"/>
                         <var name="o3mr_fg" packages="met_stage_out"/>
+                        <var_struct name="chemopp_input" packages="met_stage_out"/>
 		</stream>
 
 		<stream name="surface" 
@@ -916,9 +922,6 @@
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"/>
-
-                        <var name="qo3" array_group="passive" units="kg kg^{-1}"
-                             description="Ozone mixing ratio"/>
                 </var_array>
 
                 <!-- Climatology for ocean mixed-layer depth -->
@@ -1163,4 +1166,12 @@
                 <var name="precipw" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="precipitable water"/>
         </var_struct>
+
+
+<!-- ========================================================================================================= -->
+<!-- include ./../core_atmosphere/chemistry/Registry_chemistry.xml to read the monthly-mean data used          -->
+<!-- in the linearized CHEM2D-OPP (McCormack et al, 2006).                                                     -->
+#include "../core_atmosphere/chemistry/Registry_chems.xml"
+
+
 </registry>

--- a/src/core_init_atmosphere/mpas_chemistry_init.F
+++ b/src/core_init_atmosphere/mpas_chemistry_init.F
@@ -1,0 +1,1 @@
+./../core_atmosphere/chemistry/mpas_chemistry_init.F

--- a/src/core_init_atmosphere/mpas_chemistry_init_2DOPP.F
+++ b/src/core_init_atmosphere/mpas_chemistry_init_2DOPP.F
@@ -1,0 +1,1 @@
+./../core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F

--- a/src/core_init_atmosphere/mpas_chemistry_packages.F
+++ b/src/core_init_atmosphere/mpas_chemistry_packages.F
@@ -1,0 +1,1 @@
+./../core_atmosphere/chemistry/mpas_chemistry_packages.F

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -19,7 +19,7 @@ module init_atm_cases
    use mpas_timer
    use mpas_init_atm_static
    use mpas_init_atm_surface
-   use mpas_init_atm_o3mr
+!  use mpas_init_atm_o3mr
    use mpas_atmphys_constants, only: svpt0,svp1,svp2,svp3
    use mpas_atmphys_functions
    use mpas_atmphys_initialize_real
@@ -256,7 +256,7 @@ module init_atm_cases
                                    diag, diag_physics, config_init_case, block_ptr % dimensions, block_ptr % configs)
             
             if (config_met_interp) then
-               call init_atm_o3mr(mesh, block_ptr % configs, fg, diag ,state)
+!              call init_atm_o3mr(mesh, block_ptr % configs, fg, diag ,state)
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
             end if
 
@@ -2589,6 +2589,7 @@ module init_atm_cases
 
       integer :: nfglevels_actual
       integer, pointer :: index_qv
+      integer, pointer :: index_qo3
 
       integer, dimension(5) :: interp_list
       real (kind=RKIND) :: maskval
@@ -2723,6 +2724,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: t_fg
       real (kind=RKIND), dimension(:,:), pointer :: rh_fg
       real (kind=RKIND), dimension(:,:), pointer :: sh_fg
+      real (kind=RKIND), dimension(:,:), pointer :: o3mr_fg
       real (kind=RKIND), dimension(:,:), pointer :: gfs_z
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
       real (kind=RKIND), dimension(:,:), pointer :: st_fg
@@ -2861,6 +2863,7 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 't', t_fg)
       call mpas_pool_get_array(fg, 'rh', rh_fg)
       call mpas_pool_get_array(fg, 'sh', sh_fg)
+      call mpas_pool_get_array(fg, 'o3', o3mr_fg)
       call mpas_pool_get_array(fg, 'gfs_z', gfs_z)
       call mpas_pool_get_array(fg, 'p', p_fg)
 
@@ -2869,6 +2872,7 @@ module init_atm_cases
       nz = nz1 + 1
 
       call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_dimension(state, 'index_qo3', index_qo3)
 
       xnutr = 0.
       zd = 12000.
@@ -3404,6 +3408,7 @@ module init_atm_cases
              trim(field % field) == 'TT' .or. &
              trim(field % field) == 'RH' .or. &
              trim(field % field) == 'SPECHUMD' .or. &
+             trim(field % field) == 'O3MR' .or. &
              trim(field % field) == 'GHT' .or. &
              trim(field % field) == 'PMSL' .or. &
              trim(field % field) == 'PSFC' .or. &
@@ -3581,6 +3586,13 @@ module init_atm_cases
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'sh', destField2d)
+               ndims = 2
+            else if (trim(field % field) == 'O3MR') then
+               call mpas_log_write('Interpolating O3MR at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'o3', destField2d)
                ndims = 2
             else if (trim(field % field) == 'GHT') then
                call mpas_log_write('Interpolating GHT at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
@@ -4528,6 +4540,7 @@ call mpas_log_write('Done with soil consistency check')
       !  
       allocate(sorted_arr(2,nfglevels_actual))
 
+
       do iCell=1,nCells
 
          ! T
@@ -4584,6 +4597,25 @@ call mpas_log_write('Done with soil consistency check')
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
             if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
+         end do
+
+
+         ! QO3: if first-guess values are negative, set those values to zero before
+         ! vertical interpolation.
+         sorted_arr(:,:) = -999.0
+         scalars(index_qo3,:,iCell) = 0._RKIND
+         do k = 1, nfglevels_actual
+            sorted_arr(1,k) = z_fg(k,iCell)
+            if (vert_level(k) == 200100.0) sorted_arr(1,k) = 99999.0
+            sorted_arr(2,k) = max(0._RKIND,o3mr_fg(k,iCell))
+         end do
+         call mpas_quicksort(nfglevels_actual, sorted_arr)
+         do k = nVertLevels, 1, -1
+            target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
+            scalars(index_qo3,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+                                sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
+            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) &
+                scalars(index_qo3,k,iCell) = scalars(index_qo3,k+1,iCell)
          end do
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -19,10 +19,10 @@ module init_atm_cases
    use mpas_timer
    use mpas_init_atm_static
    use mpas_init_atm_surface
-!  use mpas_init_atm_o3mr
    use mpas_atmphys_constants, only: svpt0,svp1,svp2,svp3
    use mpas_atmphys_functions
    use mpas_atmphys_initialize_real
+   use mpas_chemistry_init
    use mpas_log, only : mpas_log_write
 
    ! Added only clause to keep xlf90 from getting confused from the overloaded abs intrinsic in mpas_timekeeping
@@ -89,6 +89,12 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: lonCell
       real (kind=RKIND), dimension(:), pointer :: ter
       integer, dimension(:), pointer :: bdyMaskCell
+
+      !
+      ! Initialization of the CHEM2D-OPP data:
+      !
+      logical, pointer :: config_use_chemopp
+      type (mpas_pool_type), pointer :: chemopp_input
 
 
       call mpas_pool_get_config(domain % blocklist % configs, 'config_init_case', config_init_case)
@@ -256,8 +262,13 @@ module init_atm_cases
                                    diag, diag_physics, config_init_case, block_ptr % dimensions, block_ptr % configs)
             
             if (config_met_interp) then
-!              call init_atm_o3mr(mesh, block_ptr % configs, fg, diag ,state)
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
+
+               call mpas_pool_get_config(block_ptr % configs, 'config_use_chemopp', config_use_chemopp)
+               if(config_use_chemopp) then
+                  call mpas_pool_get_subpool(block_ptr % structs, 'chemopp_input', chemopp_input)
+                  call chemistry_init2DOPP(mesh,chemopp_input)
+               end if
             end if
 
             block_ptr => block_ptr % next
@@ -2677,6 +2688,7 @@ module init_atm_cases
       logical, pointer :: config_tc_vertical_grid
       character (len=StrKIND), pointer :: config_specified_zeta_levels
       logical, pointer :: config_use_spechumd
+      logical, pointer :: config_use_chemopp
       integer, pointer :: config_nfglevels
       integer, pointer :: config_nfgsoillevels
       logical, pointer :: config_smooth_surfaces
@@ -2755,6 +2767,7 @@ module init_atm_cases
       call mpas_pool_get_config(configs, 'config_tc_vertical_grid', config_tc_vertical_grid)
       call mpas_pool_get_config(configs, 'config_specified_zeta_levels', config_specified_zeta_levels)
       call mpas_pool_get_config(configs, 'config_use_spechumd', config_use_spechumd)
+      call mpas_pool_get_config(configs, 'config_use_chemopp', config_use_chemopp)
       call mpas_pool_get_config(configs, 'config_nfglevels', config_nfglevels)
       call mpas_pool_get_config(configs, 'config_nfgsoillevels', config_nfgsoillevels)
       call mpas_pool_get_config(configs, 'config_smooth_surfaces', config_smooth_surfaces)
@@ -4602,21 +4615,23 @@ call mpas_log_write('Done with soil consistency check')
 
          ! QO3: if first-guess values are negative, set those values to zero before
          ! vertical interpolation.
-         sorted_arr(:,:) = -999.0
-         scalars(index_qo3,:,iCell) = 0._RKIND
-         do k = 1, nfglevels_actual
-            sorted_arr(1,k) = z_fg(k,iCell)
-            if (vert_level(k) == 200100.0) sorted_arr(1,k) = 99999.0
-            sorted_arr(2,k) = max(0._RKIND,o3mr_fg(k,iCell))
-         end do
-         call mpas_quicksort(nfglevels_actual, sorted_arr)
-         do k = nVertLevels, 1, -1
-            target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
-            scalars(index_qo3,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
-                                sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) &
-                scalars(index_qo3,k,iCell) = scalars(index_qo3,k+1,iCell)
-         end do
+         if(config_use_chemopp) then
+            sorted_arr(:,:) = -999.0
+            scalars(index_qo3,:,iCell) = 0._RKIND
+            do k = 1, nfglevels_actual
+               sorted_arr(1,k) = z_fg(k,iCell)
+               if (vert_level(k) == 200100.0) sorted_arr(1,k) = 99999.0
+               sorted_arr(2,k) = max(0._RKIND,o3mr_fg(k,iCell))
+            end do
+            call mpas_quicksort(nfglevels_actual, sorted_arr)
+            do k = nVertLevels, 1, -1
+               target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
+               scalars(index_qo3,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+                                   sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
+               if (target_z < z_fg(1,iCell) .and. k < nVertLevels) &
+                   scalars(index_qo3,k,iCell) = scalars(index_qo3,k+1,iCell)
+            end do
+         end if
 
 
          ! GHT

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -104,6 +104,7 @@ module init_atm_core_interface
 
       use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
+      use mpas_chemistry_packages, only : chemistry_setup_packages
 
       implicit none
 
@@ -115,6 +116,7 @@ module init_atm_core_interface
       logical, pointer :: initial_conds, sfc_update, lbcs
       logical, pointer :: gwd_stage_in, gwd_stage_out, vertical_stage_in, vertical_stage_out, met_stage_in, met_stage_out
       logical, pointer :: config_native_gwd_static, config_static_interp, config_vertical_grid, config_met_interp
+      logical, pointer :: config_use_chemopp
       integer, pointer :: config_init_case
 
 
@@ -201,6 +203,14 @@ module init_atm_core_interface
                         (.not. config_static_interp) .and. &
                         (.not. config_vertical_grid)
          met_stage_out = config_met_interp
+
+         !
+         ! initialize package chem2dopp_in to initialize the CHEM2DOPP data:
+         call mpas_pool_get_config(configs, 'config_use_chemopp', config_use_chemopp)
+         if(config_use_chemopp) then
+            ierr = 0
+            ierr = chemistry_setup_packages(configs,packages,iocontext,1)
+         endif
 
       else if (config_init_case == 8) then
          gwd_stage_in = .false.


### PR DESCRIPTION
This PR moves the interpolation of the CHEM2D-OPP input data to the MPAS mesh to src/core_init_atmosphere. The interpolated OPPpres and OPPdata are now available in the initial conditions file.

Modified and added files:
M       src/core_atmosphere/Registry.xml
M       src/core_atmosphere/chemistry/Makefile
M       src/core_atmosphere/chemistry/Registry_chems.xml
M       src/core_atmosphere/chemistry/chemistry_opp/o3_gfs.F
M       src/core_atmosphere/chemistry/mpas_chemistry_driver.F
M       src/core_atmosphere/chemistry/mpas_chemistry_init.F
A       src/core_atmosphere/chemistry/mpas_chemistry_init_2DOPP.F
M       src/core_atmosphere/chemistry/mpas_chemistry_interface.F
M       src/core_atmosphere/chemistry/mpas_chemistry_manager.F
M       src/core_atmosphere/chemistry/mpas_chemistry_opp.F
M       src/core_atmosphere/chemistry/mpas_chemistry_packages.F
M       src/core_atmosphere/mpas_atm_core.F
M       src/core_atmosphere/physics/mpas_atmphys_control.F
M       src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
M       src/core_init_atmosphere/Makefile
M       src/core_init_atmosphere/Registry.xml
A       src/core_init_atmosphere/mpas_chemistry_init.F
A       src/core_init_atmosphere/mpas_chemistry_init_2DOPP.F
A       src/core_init_atmosphere/mpas_chemistry_packages.F
M       src/core_init_atmosphere/mpas_init_atm_cases.F
M       src/core_init_atmosphere/mpas_init_atm_core_interface.F